### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can decide between storing the login token into this data storage, or in a c
 
 
 After login, the system checks if the user is member of an `admin`-role.
-It also can be easily changed according any demand, but I recommend to use the <Authorized /> Component.
+It also can be easily changed according any demand, but I recommend to use the `<Authorized />` Component.
 
 | Authorized props  | Type | Description |
 | ------------- | ------------- | ------------- |


### PR DESCRIPTION
Fixes links on the **Short Documentation and Structure** section. Also, added backticks on the `<Authorized />` text part because markdown was parsing it as HTML and was not being rendered as text string.